### PR TITLE
Look for duration in format if not available in stream

### DIFF
--- a/src/mediacatch_s2t/uploader.py
+++ b/src/mediacatch_s2t/uploader.py
@@ -76,11 +76,17 @@ class Uploader:
             if probe.return_code:
                 return 0, probe.error
             else:
-                for stream in probe.json['streams']:
-                    if stream['codec_type'] == 'audio':
-                        return int(float(stream['duration']) * 1000), stream
-                else:
-                    return 0, "The file doesn't have an audio track"
+                try:
+                    for stream in probe.json['streams']:
+                        if stream['codec_type'] == 'audio':
+                            return int(float(stream['duration']) * 1000), stream
+                    else:
+                        return 0, "The file doesn't have an audio track"
+                except:
+                    if 'duration' in probe.json['format']:
+                        return int(float(probe.json['format']['duration']) * 1000), probe.json['format']
+                    else:
+                        return 0, "Duration couldn't be found for audio track"
         except OSError as e:
             return 0, 'FFmpeg not installed (sudo apt install ffmpeg)'
 


### PR DESCRIPTION
Fixes https://github.com/mediacatch/s3-upload-api/issues/124

We first check audio stream for duration in case video and audio streams are not of same length.
If duration isn't found the format field is used as backup.